### PR TITLE
Migrar informe a usar API de OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Generador Automático de Informes de Análisis de Tweets
 
-Este proyecto implementa un sistema para analizar automáticamente un conjunto de tweets. Utiliza un Modelo de Lenguaje Grande (LLM) configurado a través de Ollama para:
+Este proyecto implementa un sistema para analizar automáticamente un conjunto de tweets. Utiliza un Modelo de Lenguaje Grande (LLM) accesible mediante la API de OpenAI para:
 1.  **Extraer categorías temáticas** de una muestra de tweets.
 2.  **Clasificar** cada tweet dentro de las categorías extraídas.
 3.  **Calcular estadísticas** (distribución de sentimiento, engagement) para cada categoría.
@@ -17,13 +17,12 @@ El sistema está diseñado para ser flexible, permitiendo configurar el modelo L
 -   **Generación de Informes**: Crea informes completos en Markdown, incluyendo resúmenes, estadísticas y ejemplos por categoría.
 -   **Estructura Organizada**: Mantiene los logs, tweets categorizados (caché) y reportes finales en directorios separados.
 -   **Configuración Centralizada**: Utiliza un archivo `.env` para gestionar todas las configuraciones importantes.
--   **Manejo de Modelos**: Permite especificar fácilmente qué modelo LLM (disponible en Ollama) se debe usar.
+-   **Manejo de Modelos**: Permite especificar fácilmente qué modelo LLM de OpenAI se debe usar.
 
 ## Requisitos
 
 -   **Python 3.11**: Se recomienda usar `conda` para gestionar el entorno.
--   **Ollama**: Debe estar instalado y ejecutándose. [Instrucciones de Ollama](https://ollama.com/)
--   **Un Modelo LLM en Ollama**: El modelo especificado en `.env` (por ejemplo, `gemma3:latest`, `phi4`, `granite3.2:latest`, etc.) debe estar descargado (`ollama pull <nombre_modelo>`).
+-   **Cuenta de OpenAI** con una API key válida. La clave debe estar disponible en la variable de entorno `OPENAI_API_KEY`.
 -   **Dependencias de Python**: Listadas en `requirements.txt`.
 
 ## Instalación y Configuración
@@ -52,13 +51,9 @@ Sigue estos pasos para poner en marcha el proyecto:
     pip install -r requirements.txt
     ```
 
-4.  **Configurar Ollama**:
-    -   Asegúrate de que Ollama esté instalado y ejecutándose. Por defecto, debería estar accesible en `http://127.0.0.1:11434`.
-    -   Descarga el modelo LLM que deseas utilizar. Por ejemplo, para usar `granite3.2:latest`:
-        ```bash
-        ollama pull granite3.2:latest
-        ```
-        *Nota: Puedes usar cualquier otro modelo compatible con Ollama.*
+4.  **Configurar la API de OpenAI**:
+    -   Define la variable de entorno `OPENAI_API_KEY` con tu clave de OpenAI.
+    -   En el archivo `.env` se especifica el modelo a utilizar.
 
 5.  **Preparar Datos de Entrada**:
     -   Coloca tu archivo de tweets en formato JSON dentro del directorio `data/`. El script espera por defecto un archivo llamado `DATA_FILE`, pero puedes cambiarlo en `.env` si es necesario. Asegúrate de que cada tweet en el JSON tenga al menos las claves `text`, `sentiment`, `likes`, `retweets`, `replies`.
@@ -70,13 +65,8 @@ Sigue estos pasos para poner en marcha el proyecto:
     ```dotenv
     # --- Configuración Obligatoria ---
 
-    # URL de la API de Ollama (normalmente no necesita cambio)
-    OLLAMA_API_URL=http://127.0.0.1:11434/api/generate
-
-    # Nombre EXACTO del modelo LLM instalado en Ollama
-    # Ejemplo: MODEL_NAME=gemma3:latest
-    # Ejemplo: MODEL_NAME=mistral:7b
-    MODEL_NAME=granite3.2:latest
+    # Nombre EXACTO del modelo de OpenAI que se va a utilizar
+    MODEL_NAME=gpt-4.1-nano-2025-04-14
 
     # --- Configuración de Archivos y Directorios ---
 
@@ -204,7 +194,7 @@ atribus_informe/
 ## Solución de Problemas Comunes
 
 -   **`FileNotFoundError`**: Verifica que la ruta en `TWEET_DATA_PATH` en `.env` sea correcta y que el archivo exista. Asegúrate de ejecutar `python main.py` desde la raíz del proyecto.
--   **Errores de Conexión con Ollama**: Asegúrate de que Ollama esté ejecutándose y sea accesible en la URL especificada en `OLLAMA_API_URL`. Verifica que el `MODEL_NAME` en `.env` esté correctamente escrito y que el modelo esté descargado (`ollama list`).
+-   **Errores de Conexión con OpenAI**: verifica que la variable `OPENAI_API_KEY` esté definida y que tengas acceso a la API de OpenAI.
 -   **Errores de `KeyError`**: Revisa que tu archivo JSON de tweets contenga las claves esperadas (`text`, `sentiment`, `likes`, `retweets`, `replies`).
 -   **Proceso Lento**: La extracción de categorías y la clasificación pueden tardar, especialmente con muchos tweets o modelos LLM grandes. La caché ayuda en ejecuciones posteriores. Considera usar un `BATCH_SIZE` más pequeño si tienes problemas de memoria.
 -   **Pocas Categorías Extraídas**: Si el LLM no genera suficientes categorías (menos de `MIN_CATEGORIES`), el script se detendrá. Puedes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm==4.66.1
 matplotlib==3.8.2
 pandas==2.1.3
 python-dotenv==1.0.0
+openai==1.3.5

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Módulo para generar informes utilizando ollama.
+Módulo para generar informes utilizando la API de OpenAI.
 """
 
 import os
@@ -10,43 +10,40 @@ from datetime import datetime
 from dotenv import load_dotenv
 import logging
 from typing import Dict, List, Any
-import requests
-import time
+import openai
 import json
 
 # Cargar variables de entorno
 load_dotenv()
 
 # Obtener variables desde .env (si existen)
-OLLAMA_API_URL = os.getenv("OLLAMA_API_URL")
 MODEL_NAME = os.getenv("MODEL_NAME")
+
+# Configurar la clave de API de OpenAI
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 logger = logging.getLogger(__name__)
 
 def query_llm(prompt: str) -> str:
     """
-    Consulta al modelo {MODEL_NAME} mediante la API de Ollama.
-    
+    Consulta al modelo {MODEL_NAME} mediante la API de OpenAI.
+
     Args:
         prompt (str): Prompt para el modelo.
-        
+
     Returns:
         str: Respuesta del modelo.
     """
     try:
-        payload = {
-            "model": MODEL_NAME,
-            "prompt": prompt,
-            "stream": False,
-            "temperature": 0.7
-        }
-        
-        response = requests.post(OLLAMA_API_URL, json=payload)
-        response.raise_for_status()
-        
-        return response.json().get("response", "").strip()
-        
-    except requests.RequestException as e:
+        response = openai.ChatCompletion.create(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+
+        return response.choices[0].message.content.strip()
+
+    except Exception as e:
         logger.error(f"Error al consultar {MODEL_NAME}: {str(e)}")
         return "No se pudo generar el contenido debido a un error de conexión con el modelo."
 
@@ -119,7 +116,7 @@ El análisis debe ser objetivo y basado en los datos proporcionados.
 
 def generate_category_conclusion(category: str, stats: Dict[str, Any]) -> str:
     """
-    Genera una conclusión detallada para una categoría utilizando Gemma3.
+    Genera una conclusión detallada para una categoría utilizando {MODEL_NAME}.
     
     Args:
         category (str): Nombre de la categoría.
@@ -186,7 +183,7 @@ El análisis debe ser objetivo y basado en los datos proporcionados.
 
 def generate_final_summary(all_stats: Dict[str, Dict[str, Any]]) -> str:
     """
-    Genera un resumen general detallado del informe utilizando Gemma3.
+    Genera un resumen general detallado del informe utilizando {MODEL_NAME}.
     
     Args:
         all_stats (Dict[str, Dict[str, Any]]): Estadísticas de todas las categorías.

--- a/src/tweet_categorizer.py
+++ b/src/tweet_categorizer.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 """
-Módulo para categorizar tweets utilizando el modelo Gemma3 (12b).
+Módulo para categorizar tweets utilizando un modelo de OpenAI.
 """
 
 import logging
 import json
-import requests
+import openai
 from typing import List, Dict, Any, Set, Tuple
 from collections import defaultdict
 import re
@@ -18,9 +18,11 @@ import random
 # Cargar variables de entorno
 load_dotenv()
 
-# URL de la API de Ollama y Nombre del Modelo (cargados desde .env)
-OLLAMA_API_URL = os.getenv("OLLAMA_API_URL")
+# Nombre del modelo de OpenAI (cargado desde .env)
 MODEL_NAME = os.getenv("MODEL_NAME")
+
+# Configurar la clave de API de OpenAI desde la variable de entorno
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 # Configuraciones de extracción de categorías desde .env
 CATEGORY_SAMPLE_SIZE = int(os.getenv("CATEGORY_SAMPLE_SIZE", 200)) # Tamaño de muestra para extracción
@@ -28,10 +30,10 @@ MIN_CATEGORIES = int(os.getenv("MIN_CATEGORIES", 5))           # Mínimo de cate
 MAX_CATEGORIES = int(os.getenv("MAX_CATEGORIES", 8))           # Máximo de categorías a extraer
 
 # Comprobar variables críticas
-if not OLLAMA_API_URL or not MODEL_NAME:
-    logger = logging.getLogger(__name__) 
-    logger.error("Las variables OLLAMA_API_URL y MODEL_NAME deben estar definidas en el archivo .env")
-    raise ValueError("Faltan variables críticas OLLAMA_API_URL o MODEL_NAME en .env")
+if not openai.api_key or not MODEL_NAME:
+    logger = logging.getLogger(__name__)
+    logger.error("Las variables OPENAI_API_KEY y MODEL_NAME deben estar definidas en el entorno")
+    raise ValueError("Faltan variables críticas OPENAI_API_KEY o MODEL_NAME")
 
 # Configuración de logging para manejar caracteres Unicode
 logger = logging.getLogger(__name__)
@@ -46,28 +48,24 @@ for handler in logger.handlers + logging.getLogger().handlers:
 
 def query_llm(prompt: str) -> str:
     """
-    Consulta al modelo LLM configurado mediante la API de Ollama.
-    
+    Consulta al modelo LLM configurado mediante la API de OpenAI.
+
     Args:
         prompt (str): Prompt para el modelo.
-        
+
     Returns:
         str: Respuesta del modelo.
     """
     try:
-        payload = {
-            "model": MODEL_NAME,
-            "prompt": prompt,
-            "stream": False,
-            "temperature": 0.2
-        }
-        
-        response = requests.post(OLLAMA_API_URL, json=payload)
-        response.raise_for_status()
-        
-        return response.json().get("response", "").strip()
-        
-    except requests.RequestException as e:
+        response = openai.ChatCompletion.create(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+
+        return response.choices[0].message.content.strip()
+
+    except Exception as e:
         logger.error(f"Error al consultar {MODEL_NAME}: {str(e)}")
         return ""
 


### PR DESCRIPTION
## Summary
- migrate categorizer and reporter to OpenAI API
- update dependencies with `openai`
- update README to use OpenAI and provide new `.env` example

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q src main.py`


------
https://chatgpt.com/codex/tasks/task_e_684958d8d94883259093d2988cd3cbf8